### PR TITLE
Security Exception 처리 및 인증메일 기능 리팩토링

### DIFF
--- a/mail-sender/src/main/java/univ/study/recruitjogbo/ConfirmEmailTemplate.java
+++ b/mail-sender/src/main/java/univ/study/recruitjogbo/ConfirmEmailTemplate.java
@@ -1,9 +1,0 @@
-package univ.study.recruitjogbo;
-
-public interface ConfirmEmailTemplate {
-
-    String subject = "[Recruit Jogbo] 사용자 인증 메일입니다.";
-
-    String baseUrl = "http://localhost:8080/api/confirm/email?token=";
-
-}

--- a/mail-sender/src/main/java/univ/study/recruitjogbo/EmailConfirmRequestMessage.java
+++ b/mail-sender/src/main/java/univ/study/recruitjogbo/EmailConfirmRequestMessage.java
@@ -10,6 +10,6 @@ public class EmailConfirmRequestMessage {
 
     private String targetEmail;
 
-    private String emailConfirmToken;
+    private String emailConfirmLink;
 
 }

--- a/mail-sender/src/main/java/univ/study/recruitjogbo/MailRequestListener.java
+++ b/mail-sender/src/main/java/univ/study/recruitjogbo/MailRequestListener.java
@@ -3,6 +3,7 @@ package univ.study.recruitjogbo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import javax.mail.MessagingException;
@@ -12,14 +13,18 @@ import javax.mail.MessagingException;
 @Slf4j
 public class MailRequestListener {
 
+    private static final String subject = "[RecruitJogbo] 가입 인증 메일입니다.";
+
     private final MailService mailService;
+
+    @Value("${confirm.link}")
+    String confirmLink;
 
     @RabbitListener(queues = "email.confirm")
     public void receiveMessage(final EmailConfirmRequestMessage message) throws MessagingException {
         String targetEmail = message.getTargetEmail();
-        String subject = ConfirmEmailTemplate.subject;
-        String token = ConfirmEmailTemplate.baseUrl + message.getEmailConfirmToken();
-        mailService.sendConfirmMail(targetEmail, subject, token);
+        String confirmLink = message.getEmailConfirmLink();
+        mailService.sendConfirmMail(targetEmail, subject, confirmLink);
         log.info("Send confirm mail to [{}]", targetEmail);
     }
 

--- a/mail-sender/src/main/java/univ/study/recruitjogbo/MailService.java
+++ b/mail-sender/src/main/java/univ/study/recruitjogbo/MailService.java
@@ -18,9 +18,9 @@ public class MailService {
 
     private final TemplateEngine templateEngine;
 
-    public void sendConfirmMail(String to, String subject, String token) throws MessagingException {
+    public void sendConfirmMail(String to, String subject, String confirmLink) throws MessagingException {
         Context context = new Context();
-        context.setVariable("token", token);
+        context.setVariable("confirmLink", confirmLink);
         String htmlContent = templateEngine.process("mailContent", context);
 
         MimeMessage mimeMessage = mailSender.createMimeMessage();

--- a/mail-sender/src/main/resources/templates/mailContent.html
+++ b/mail-sender/src/main/resources/templates/mailContent.html
@@ -13,7 +13,7 @@
     <div class="card-body">
         <h5 class="card-title">Recruit Jogbo 가입 인증 메일입니다.</h5>
         <p class="card-text">인증을 위해 아래 버튼을 클릭해 주세요. 혹시 가입하신 적이 없다면 paul26375@gmail.com으로 문의 주시기 바랍니다.</p>
-        <a th:href="${token}" class="btn btn-primary">인증하기</a>
+        <a th:href="${confirmLink}" class="btn btn-primary">인증하기</a>
     </div>
 </div>
 </body>

--- a/recruit-jogbo-api/src/main/resources/application.yml
+++ b/recruit-jogbo-api/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
     basename: i18n/messages
     encoding: UTF-8
 server:
-  port: 8082
+  port: 8080
 jwt:
   token:
     header: api_key
@@ -30,7 +30,7 @@ spring:
     basename: i18n/messages
     encoding: UTF-8
 server:
-  port: 8082
+  port: 8080
 jwt:
   token:
     header: api_key
@@ -59,7 +59,7 @@ logging:
   level:
     org.hibernate.type: trace
 server:
-  port: 8082
+  port: 8080
 jwt:
   token:
     header: api_key

--- a/recruit-jogbo-common/src/main/java/univ/study/recruitjogbo/member/confirm/ConfirmationTokenRepository.java
+++ b/recruit-jogbo-common/src/main/java/univ/study/recruitjogbo/member/confirm/ConfirmationTokenRepository.java
@@ -6,6 +6,8 @@ import java.util.Optional;
 
 public interface ConfirmationTokenRepository extends JpaRepository<ConfirmationToken, Long> {
 
+    Optional<ConfirmationToken> findByUserEmail(String email);
+
     Optional<ConfirmationToken> findByConfirmationToken(String confirmationToken);
 
 }

--- a/recruit-jogbo-common/src/main/java/univ/study/recruitjogbo/message/EmailConfirmRequestMessage.java
+++ b/recruit-jogbo-common/src/main/java/univ/study/recruitjogbo/message/EmailConfirmRequestMessage.java
@@ -10,6 +10,6 @@ public class EmailConfirmRequestMessage {
 
     private String targetEmail;
 
-    private String emailConfirmToken;
+    private String emailConfirmLink;
 
 }

--- a/recruit-jogbo-common/src/main/resources/i18n/messages.properties
+++ b/recruit-jogbo-common/src/main/resources/i18n/messages.properties
@@ -2,3 +2,4 @@ error.notfound=NotFound
 error.notfound.details=Could not found [{0}] with [{1}]
 error.auth=AuthenticationFailed
 error.auth.details=Authentication error (cause: [{0}])
+confirm.link=http://localhost:8080/api/confirm/email?token=

--- a/recruit-jogbo-web/src/main/java/univ/study/recruitjogbo/RecruitJogboWeb.java
+++ b/recruit-jogbo-web/src/main/java/univ/study/recruitjogbo/RecruitJogboWeb.java
@@ -38,7 +38,7 @@ public class RecruitJogboWeb {
 
         @Override
         public void run(String... args) {
-            Member member = memberService.join("paul", "1234", "hello@ynu.ac.kr");
+            Member member = memberService.join("paul", "1234", "paul5813@ynu.ac.kr");
             postService.write(member.getId(),"삼성", RecruitType.RESUME, LocalDate.now(), "이러저러했다.");
             postService.write(member.getId(),"삼성", RecruitType.INTERVIEW, LocalDate.now(), "이러저러했다.");
             postService.write(member.getId(),"라인", RecruitType.INTERVIEW, LocalDate.now().minusDays(10), "저러이러했다.");

--- a/recruit-jogbo-web/src/main/java/univ/study/recruitjogbo/configure/WebSecurityConfigure.java
+++ b/recruit-jogbo-web/src/main/java/univ/study/recruitjogbo/configure/WebSecurityConfigure.java
@@ -18,6 +18,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.access.expression.WebExpressionVoter;
 import org.springframework.security.web.util.matcher.RegexRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
+import univ.study.recruitjogbo.security.AccessDeniedHandlerImpl;
+import univ.study.recruitjogbo.security.EntryPointUnauthorizedHandler;
 import univ.study.recruitjogbo.security.PostEditableVoter;
 
 import java.util.ArrayList;
@@ -35,6 +37,10 @@ public class WebSecurityConfigure extends WebSecurityConfigurerAdapter {
     private final PasswordEncoder passwordEncoder;
 
     private final UserDetailsService userDetailsService;
+
+    private final AccessDeniedHandlerImpl accessDeniedHandlerImpl;
+
+    private final EntryPointUnauthorizedHandler entryPointUnauthorizedHandler;
 
     @Bean
     @Override
@@ -63,8 +69,14 @@ public class WebSecurityConfigure extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http
+                .exceptionHandling()
+                    .accessDeniedHandler(accessDeniedHandlerImpl)
+                    .authenticationEntryPoint(entryPointUnauthorizedHandler)
+                    .and()
                 .authorizeRequests()
                     .antMatchers("/member").permitAll()
+                    .antMatchers("/member/confirm").hasRole("UNCONFIRMED")
+                    .antMatchers("/post/**").hasRole("MEMBER")
                     .anyRequest().authenticated()
                     .accessDecisionManager(accessDecisionManager())
                     .and()
@@ -84,7 +96,9 @@ public class WebSecurityConfigure extends WebSecurityConfigurerAdapter {
 
     @Override
     public void configure(WebSecurity web) {
-        web.ignoring().antMatchers("/h2/**");
+        web.ignoring()
+                .antMatchers("/h2/**")
+                .antMatchers("/error");
     }
 
 }

--- a/recruit-jogbo-web/src/main/java/univ/study/recruitjogbo/controller/AuthenticationController.java
+++ b/recruit-jogbo-web/src/main/java/univ/study/recruitjogbo/controller/AuthenticationController.java
@@ -3,14 +3,27 @@ package univ.study.recruitjogbo.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import univ.study.recruitjogbo.member.MemberService;
 
 @Controller
 @RequiredArgsConstructor
 public class AuthenticationController {
 
+    private final MemberService memberService;
+
     @GetMapping("/login")
     public String loginForm() {
         return "login";
+    }
+
+    @GetMapping("/confirm")
+    public String confirmForm() {
+        return "confirm";
+    }
+
+    @GetMapping("/success")
+    public String success() {
+        return "success";
     }
 
 }

--- a/recruit-jogbo-web/src/main/java/univ/study/recruitjogbo/controller/MemberController.java
+++ b/recruit-jogbo-web/src/main/java/univ/study/recruitjogbo/controller/MemberController.java
@@ -1,12 +1,17 @@
 package univ.study.recruitjogbo.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import univ.study.recruitjogbo.error.NotFoundException;
+import univ.study.recruitjogbo.member.Member;
 import univ.study.recruitjogbo.member.MemberService;
 import univ.study.recruitjogbo.request.JoinRequest;
+import univ.study.recruitjogbo.security.AuthMember;
 
 import javax.validation.Valid;
 import java.util.Map;
@@ -34,6 +39,16 @@ public class MemberController {
                 request.getPassword(),
                 request.getEmail()
         );
+        return "redirect:/login";
+    }
+
+    @PostMapping("/member/confirm")
+    public String emailConfirm(@AuthenticationPrincipal AuthMember member) {
+        String email = memberService.findById(member.getId())
+                .map(Member::getEmail)
+                .orElseThrow(() -> new NotFoundException(Member.class, member.getId().toString()));
+        memberService.sendConfirmEmail(email);
+        SecurityContextHolder.clearContext();
         return "redirect:/login";
     }
 

--- a/recruit-jogbo-web/src/main/java/univ/study/recruitjogbo/security/AccessDeniedHandlerImpl.java
+++ b/recruit-jogbo-web/src/main/java/univ/study/recruitjogbo/security/AccessDeniedHandlerImpl.java
@@ -1,0 +1,28 @@
+package univ.study.recruitjogbo.security;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import univ.study.recruitjogbo.member.Role;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class AccessDeniedHandlerImpl implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
+        AuthMember member = (AuthMember) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String redirectUrl = "/";
+        for (GrantedAuthority grantedAuthority : member.getAuthorities()) {
+            if (grantedAuthority.getAuthority().equals(Role.UNCONFIRMED.value())) {
+                redirectUrl = "/confirm";
+            }
+        }
+        response.sendRedirect(redirectUrl);
+    }
+}

--- a/recruit-jogbo-web/src/main/java/univ/study/recruitjogbo/security/EntryPointUnauthorizedHandler.java
+++ b/recruit-jogbo-web/src/main/java/univ/study/recruitjogbo/security/EntryPointUnauthorizedHandler.java
@@ -1,0 +1,19 @@
+package univ.study.recruitjogbo.security;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class EntryPointUnauthorizedHandler implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        response.sendRedirect("/error");
+    }
+
+}

--- a/recruit-jogbo-web/src/main/resources/templates/confirm.html
+++ b/recruit-jogbo-web/src/main/resources/templates/confirm.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Confirm</title>
+</head>
+<body>
+<form th:action="@{/member/confirm}" th:method="post">
+    <button type="submit">인증하기</button>
+</form>
+</body>
+</html>

--- a/recruit-jogbo-web/src/main/resources/templates/error.html
+++ b/recruit-jogbo-web/src/main/resources/templates/error.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Error</title>
+</head>
+<body>
+오류가 발생했습니다.
+<a href="/login">로그인</a>
+</body>
+</html>

--- a/recruit-jogbo-web/src/main/resources/templates/success.html
+++ b/recruit-jogbo-web/src/main/resources/templates/success.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Success</title>
+</head>
+<body>
+요청이 처리되었습니다.
+</body>
+</html>


### PR DESCRIPTION
- 권한이 없는 경우 
EntryPointUnauthorizedHandler에서 "/error"로 redirect
- 권한이 부족한 경우 
AccessDeniedHandlerImpl에서 "/confirm"으로 redirect
- "/confirm" 요청 시 인증메일 발송
이미 발송한 적이 있는 경우 동일한 token 발송